### PR TITLE
Fix: Change Len to lenSq in projection - Update vec3.cpp

### DIFF
--- a/Chapter03/Sample00/Code/vec3.cpp
+++ b/Chapter03/Sample00/Code/vec3.cpp
@@ -74,7 +74,7 @@ float angle(const vec3& l, const vec3& r) {
 }
 
 vec3 project(const vec3& a, const vec3& b) {
-	float magBSq = len(b);
+	float magBSq = lenSq(b);
 	if (magBSq < VEC3_EPSILON) {
 		return vec3();
 	}


### PR DESCRIPTION
I detected a type error in the book and repository. The author used Length instead of SqrLength in the implementation shown in the book.

Author's implementation:
```cpp

vec3 project(const vec3 &a, const vec3 &b) {
 float magBSq = len(b);
 if (magBSq < VEC3_EPSILON) {
  return vec3();
 }
 float scale = dot(a, b) / magBSq;
 return b * scale;
}

```

Vector projection formula ``` (A . B / |B|^2) * B ```

LenSq is the calculation of the hypotenuse without radically dividing, so it can be represented as `|B| ^ 2`